### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -191,6 +191,11 @@ def register():
    
     # add keymap entry
     kc = bpy.context.window_manager.keyconfigs.addon
+
+    if kc is None:
+        print('ERROR: CAN NOT REGISTER JMESH')
+        return
+
     km = kc.keymaps.new(name='3D View', space_type='VIEW_3D')
 
     kmi = km.keymap_items.new("object.fc_primitve_mode_op", 'P', 'PRESS', shift=True, ctrl=True)


### PR DESCRIPTION
I am using blender in background mode to generate some files and I get the following exception with your plugin:

```
Exception in module register(): /home/xxx/.config/blender/2.90/scripts/addons/jmesh-tools-master/__init__.py
Traceback (most recent call last):
  File "/home/xxx/Apps/Blender/blender-2.90.0-linux64/2.90/scripts/modules/addon_utils.py", line 382, in enable
    mod.register()
  File "/home/xxx/.config/blender/2.90/scripts/addons/jmesh-tools-master/__init__.py", line 168, in register
    km = kc.keymaps.new(name='3D View', space_type='VIEW_3D')
AttributeError: 'NoneType' object has no attribute 'keymaps'
```

I worked around by adding the following code to your `__init__.py` file

```
if kc is None:
      print('ERROR: CAN NOT REGISTER JMESH')
      return
```